### PR TITLE
I think this will allow the automated build to go through

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -30,7 +30,7 @@ export default {
     /** Minify JS */
     terser(),
     /** Bundle assets references via import.meta.url */
-    importMetaAssets(),
+    importMetaAssets({warnOnError: true }),
     /** Compile JS to a lower language target */
     babel({
       babelHelpers: 'bundled',


### PR DESCRIPTION
@lizblake https://modern-web.dev/docs/building/rollup-plugin-import-meta-assets/#warnonerror is how I tracked this down. the plugin wants a direct file reference and (we are f'ing lazy) and include directories and then dynamically point to icons (which it hates).

Let the build automatically run for this patch before accepting as I'm not sure it'll fix it but I think it might.